### PR TITLE
Change .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,24 @@
 root = true
+
 [*]
 end_of_line = lf
 insert_final_newline = true
 charset = utf-8
 indent_style = space
-indent_size = 4
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.js]
+indent_size = 2
+
+[*.jsx]
+indent_size = 2
+
+[*.css]
+indent_size = 2
+
+[*.json]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "tabWidth": 2
 }


### PR DESCRIPTION
## Description
Update EditorConfig to use 2-space indentation and add comprehensive file type configurations to ensure consistent code formatting across the project. 

**Changes made:**
- Changed `indent_size` from 4 to 2 in `.editorconfig` to match existing codebase
- Added `trim_trailing_whitespace = true` for better consistency
- Added specific sections for `*.js`, `*.jsx`, `*.css`, `*.json` files with 2-space indentation
- Added special handling for `*.md` files to preserve trailing whitespace
- Updated `.prettierrc` to include `"tabWidth": 2` to align with EditorConfig

This maintenance update resolves the inconsistency between the EditorConfig settings (4 spaces) and the actual codebase indentation (2 spaces)

## Related Issue
Closes #10