### PR TITLE
Add Depandabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "06:00"
+      timezone: America/New_York
+    labels: ["dependencies", "backend"]
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      minor-and-patch-deps:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "06:30"
+      timezone: America/New_York
+    labels: ["dependencies", "frontend"]
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      minor-and-patch-deps:
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+      time: "07:00"
+      timezone: America/New_York
+    labels: ["dependencies", "ci"]


### PR DESCRIPTION
## Description
Adds `.github/dependabot.yml` to enable weekly automated dependency PRs:
- npm (`/backend`) — Sundays 06:00 ET, labels: `dependencies`, `backend`, groups minor/patch
- npm (`/frontend`) — Sundays 06:30 ET, labels: `dependencies`, `frontend`, groups minor/patch
- GitHub Actions (`/`) — Sundays 07:00 ET, labels: `dependencies`, `ci`

This reduces manual maintenance and improves security hygiene without user-facing changes.

## Related Issue
Closes #12